### PR TITLE
Update uninstall logic, install Teams Meeting add-in

### DIFF
--- a/scripted-actions/windows-scripts/Install Microsoft Teams (new).ps1
+++ b/scripted-actions/windows-scripts/Install Microsoft Teams (new).ps1
@@ -64,10 +64,19 @@ if ($null -ne $GetTeams){
 }
  
 # WebRTC uninstall logic
-$GetWebRTC = get-wmiobject Win32_Product | Where-Object IdentifyingNumber -match "{FB41EDB3-4138-4240-AC09-B5A184E8F8E4}"
+$GetWebRTC = get-wmiobject Win32_Product | Where-Object Name -match "Remote Desktop WebRTC Redirector Service"
 if ($null -ne $GetWebRTC){
-    Start-Process C:\Windows\System32\msiexec.exe -ArgumentList '/x "{FB41EDB3-4138-4240-AC09-B5A184E8F8E4}" /qn /norestart' -Wait 2>&1
+    $WebRTCProductCode = $GetWebRTC | Select-Object -ExpandProperty IdentifyingNumber
+    Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/x $WebRTCProductCode /qn /norestart" -Wait 2>&1
     Write-Host "INFO: WebRTC Install Found, uninstalling Current version of WebRTC"
+}
+
+# Teams Meeting add-in uninstall logic
+$GetAddIn = get-wmiobject Win32_Product | Where-Object Name -match "Microsoft Teams Meeting Add-in for Microsoft Office"
+if ($null -ne $GetAddIn){
+    $AddInProductCode = $GetAddIn | Select-Object -ExpandProperty IdentifyingNumber
+    Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/x $AddInProductCode /qn /norestart" -Wait 2>&1
+    Write-Host "INFO: Teams Meeting Add-in Found, uninstalling Current version of Teams Meeting Add-in"
 }
  
 # make directories to hold new install
@@ -91,6 +100,17 @@ Invoke-WebRequest -Uri $DLink2 -OutFile "C:\Windows\Temp\msteams_sa\install\MsRd
 Write-Host "INFO: Installing WebRTC component"
 Start-Process C:\Windows\System32\msiexec.exe `
 -ArgumentList '/i C:\Windows\Temp\msteams_sa\install\MsRdcWebRTCSvc_x64.msi /l*v C:\Windows\temp\NerdioManagerLogs\ScriptedActions\msteams\WebRTC_install_log.txt /qn /norestart' -Wait 2>&1
+Write-Host "INFO: Finished running installers. Check C:\Windows\Temp\msteams_sa for logs on the MSI installations."
+Write-Host "INFO: All Commands Executed; script is now finished. Allow 5 minutes for teams to appear" -ForegroundColor Green
+
+# install Teams Meeting add-in
+$TeamsVersion = (Get-AppxPackage -Name MSTeams).Version
+$TMAPath = "{0}\WINDOWSAPPS\MSTEAMS_{1}_X64__8WEKYB3D8BBWE\MICROSOFTTEAMSMEETINGADDININSTALLER.MSI" -f $env:programfiles,$TeamsVersion
+$TMAVersion = (Get-AppLockerFileInformation -Path $TMAPath | Select-Object -ExpandProperty Publisher).BinaryVersion
+$TargetDir = "{0}\Microsoft\TeamsMeetingAddin\{1}\" -f ${env:ProgramFiles(x86)},$TMAVersion
+$params = '/i "{0}" TARGETDIR="{1}" /qn ALLUSERS=1' -f $TMAPath, $TargetDir
+Write-Host "INFO: Installing Teams Meeting add-in"
+Start-Process msiexec.exe -ArgumentList $params
 Write-Host "INFO: Finished running installers. Check C:\Windows\Temp\msteams_sa for logs on the MSI installations."
 Write-Host "INFO: All Commands Executed; script is now finished. Allow 5 minutes for teams to appear" -ForegroundColor Green
  


### PR DESCRIPTION
Update the package uninstall logic to find the product code based on the package name. This will keep changes in the product code from breaking the uninstall portion of the script.

This update will also check for the Teams Meeting add-in and uninstall it if it is present, then reinstall the latest version. The meeting add-in is no longer bundled by default in the Teams installer, and must instead be installed manually from the MSIX package.