### PR TITLE
Remove double success message, add MSI logging for TMA install

### DIFF
--- a/scripted-actions/windows-scripts/Install Microsoft Teams (new).ps1
+++ b/scripted-actions/windows-scripts/Install Microsoft Teams (new).ps1
@@ -100,15 +100,13 @@ Invoke-WebRequest -Uri $DLink2 -OutFile "C:\Windows\Temp\msteams_sa\install\MsRd
 Write-Host "INFO: Installing WebRTC component"
 Start-Process C:\Windows\System32\msiexec.exe `
 -ArgumentList '/i C:\Windows\Temp\msteams_sa\install\MsRdcWebRTCSvc_x64.msi /l*v C:\Windows\temp\NerdioManagerLogs\ScriptedActions\msteams\WebRTC_install_log.txt /qn /norestart' -Wait 2>&1
-Write-Host "INFO: Finished running installers. Check C:\Windows\Temp\msteams_sa for logs on the MSI installations."
-Write-Host "INFO: All Commands Executed; script is now finished. Allow 5 minutes for teams to appear" -ForegroundColor Green
 
 # install Teams Meeting add-in
 $TeamsVersion = (Get-AppxPackage -Name MSTeams).Version
 $TMAPath = "{0}\WINDOWSAPPS\MSTEAMS_{1}_X64__8WEKYB3D8BBWE\MICROSOFTTEAMSMEETINGADDININSTALLER.MSI" -f $env:programfiles,$TeamsVersion
 $TMAVersion = (Get-AppLockerFileInformation -Path $TMAPath | Select-Object -ExpandProperty Publisher).BinaryVersion
 $TargetDir = "{0}\Microsoft\TeamsMeetingAddin\{1}\" -f ${env:ProgramFiles(x86)},$TMAVersion
-$params = '/i "{0}" TARGETDIR="{1}" /qn ALLUSERS=1' -f $TMAPath, $TargetDir
+$params = '/i "{0}" /l*v C:\Windows\temp\NerdioManagerLogs\ScriptedActions\msteams\TMA_install_log.txt TARGETDIR="{1}" /qn ALLUSERS=1' -f $TMAPath, $TargetDir
 Write-Host "INFO: Installing Teams Meeting add-in"
 Start-Process msiexec.exe -ArgumentList $params
 Write-Host "INFO: Finished running installers. Check C:\Windows\Temp\msteams_sa for logs on the MSI installations."


### PR DESCRIPTION
The success install message was listed twice (once after installing WebRTC, and again after installing the Teams Meeting add-in), so removed the prompt from the WebRTC service since the script is not finished.

Added MSI logging for the Teams Meeting add-in.