### PR TITLE
Update Storage Account Private Endpoint Script

### DIFF
--- a/scripted-actions/azure-runbooks/Enable Private Endpoint for Storage Account.ps1
+++ b/scripted-actions/azure-runbooks/Enable Private Endpoint for Storage Account.ps1
@@ -56,6 +56,7 @@ if (-not $storageAccount) {
 # Create private link service connection
 Write-Output "Creating private link service connection"
 $privateLinkServiceConnection = New-AzPrivateLinkServiceConnection -Name "$($storageAccount.Name)PrivateLinkServiceConnection" -PrivateLinkServiceId $storageAccount.Id -GroupId "file"
+Write-Output "Private link service connection created"
 
 # Get vnet
 Write-Output "Getting VNet"
@@ -79,9 +80,9 @@ if ($privateEndpoint) {
 }
 else {
 # Create private endpoint
-    Write-Output "Creating private endpoint and private link service connection"
-    $FileServiceConnection = New-AzPrivateLinkServiceConnection -Name "$($storageAccount.Name)-serviceconnection" -PrivateLinkServiceId $storageAccount.ResourceId -GroupId 'file'
+    Write-Output "Creating private endpoint and applying private link service connection"
     $privateEndpoint = New-AzPrivateEndpoint -ResourceGroupName $VNetResourceGroup -Name "$($storageAccount.Name)PrivateEndpoint" -Location $storageAccount.Location -Subnet $subnet -PrivateLinkServiceConnection $privateLinkServiceConnection
+    Write-Output "Private endpoint created"
 }
 
 


### PR DESCRIPTION
The current private endpoint script runs into multiple errors which I have fixed through trial-and-error. The first error is regarding the existing New-AzPrivateDnsVirtualNetworkLink cmdlet as the removed parameter (-RegistrationEnabled) does not exist as part of the cmdlet. Replaced it with -EnableRegistration which defaults to $true for a boolean.

The second error was related to the final step of created the private dns zone group which references $VNetResourceGroup which is in the base subscription context, so we needed to add a new switch and I added outputs to show that we switch back.

I also added some additional verbose outputs and deleted line 84 which was redundant to line 58. 