### PR TITLE
Fix Unregister Sophos script reporting success when a deletion fails

### DIFF
--- a/scripted-actions/windows-scripts/Unregister Sophos Endpoint agent in Sophos Central.ps1
+++ b/scripted-actions/windows-scripts/Unregister Sophos Endpoint agent in Sophos Central.ps1
@@ -84,7 +84,7 @@ $DeleteResponse = (Invoke-RestMethod -Method 'delete' -Headers $TenantsHeader -u
 # Check if request was successful
 Write-Output "INFO: Checking response to confirm deletion"
 Start-Sleep -Seconds 15
-if($DeleteResponse.deleted = "true"){
+if($DeleteResponse.deleted -eq "true"){
     Write-Output "INFO: Successfully deleted $AzureVMName from Sophos Central"
 }
 else {


### PR DESCRIPTION
This PR proposes a fix to `Unregister Sophos Endpoint agent in Sophos Central.ps1` so that a failed Sophos Central deletion is no longer reported as a success. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/300. You can sign in with your GitHub ID to claim ownership of the project.

### The defect

In `scripted-actions/windows-scripts/Unregister Sophos Endpoint agent in Sophos Central.ps1`, the post-delete success check uses the assignment operator `=` instead of the equality operator `-eq`:

```powershell
if($DeleteResponse.deleted = "true"){
    Write-Output "INFO: Successfully deleted $AzureVMName from Sophos Central"
}
else {
    Write-Output "Error: Unable to delete endpoint from Sophos Central"
}
```

`$DeleteResponse.deleted = "true"` does not compare anything. It assigns the string `"true"` to the `deleted` property of the response object, and the expression evaluates truthy every time. As a result the `else` branch is unreachable and the script prints `INFO: Successfully deleted ...` regardless of what the Sophos API actually returned. An operator decommissioning a VM sees a success message even when the endpoint was never removed from Sophos Central, which is exactly the case where they most need to know it failed.

### Reproducing on the current `main`

This is behavior you can confirm without any Azure or Sophos access, using only the exact conditional from the script:

```powershell
function Report($DeleteResponse) {
    if($DeleteResponse.deleted = "true"){ "reports: SUCCESS" } else { "reports: ERROR" }
}
# Simulate a response where the deletion did NOT happen:
$resp = [pscustomobject]@{ deleted = $false }
Report $resp          # -> "reports: SUCCESS"   (wrong)
$resp.deleted         # -> "true"               (the response object was mutated)
```

Swapping `=` for `-eq` gives the intended behavior: `reports: ERROR` for a failed deletion and `reports: SUCCESS` only when `deleted` is actually true, with the response object left untouched.

### The change and how it was verified

The fix is a single operator change on line 87, `=` to `-eq`, and is behavior-preserving on the success path. Verification:

- `Invoke-ScriptAnalyzer` on the file flags `PSPossibleIncorrectUsageOfAssignmentOperator` at line 87 before the change and reports it cleared afterward, with no new findings introduced and the repository-wide analyzer results otherwise unchanged.
- The reproduction above returns `reports: SUCCESS` on the unmodified file and `reports: ERROR` after the change for a failed-deletion response.
- The script continues to parse without errors.

### How this was managed

This work was tracked as a story on a live agile board imported from this repository's own issues and pull requests (71 stories, 1 label): https://eastagiletracker.com/projects/300/stories/198537 on the board at https://eastagiletracker.com/projects/300.

![board](https://raw.githubusercontent.com/eastagiletracker/NMW/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
